### PR TITLE
use msg.payload directly

### DIFF
--- a/nodes.js
+++ b/nodes.js
@@ -63,7 +63,7 @@ module.exports = (RED) => {
     });
 
     node.on('input', (msg) => {
-      cluster.setPin(n.pin, msg.payload.value)
+      cluster.setPin(n.pin, msg.payload)
       .then(() => {
 
       });


### PR DESCRIPTION
before this bugfix I could not set the output of a cluster-output node correctly - instead it would simply toogle everytime I send a message.

With this change it is possible to send a bool (true / false) as the msg.payload directly and will set the pin accordingly